### PR TITLE
builds new image from master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+FROM thanosio/thanos:master-2021-01-05-0aa07118 AS thanos
+
 FROM alpine:3.12
 
-ARG THANOS_VERSION=0.17.2
+# ARG THANOS_VERSION=0.17.2
 
 # Dependencies
 RUN apk add --update --upgrade --no-cache \
@@ -9,12 +11,13 @@ RUN apk add --update --upgrade --no-cache \
     openssl>=1.1.1i
 
 # Downwnload thanos
-RUN curl -k -LSs --output /tmp/thanos.tar.gz \
-    https://github.com/thanos-io/thanos/releases/download/v${THANOS_VERSION}/thanos-${THANOS_VERSION}.linux-amd64.tar.gz && \
-    tar -C /tmp --strip-components=1 -zoxf /tmp/thanos.tar.gz && \
-    rm -f /tmp/thanos.tar.gz && \
-    mv /tmp/thanos /bin/ && \
-    mkdir -p /thanos && \
+# RUN curl -k -LSs --output /tmp/thanos.tar.gz \
+#     https://github.com/thanos-io/thanos/releases/download/v${THANOS_VERSION}/thanos-${THANOS_VERSION}.linux-amd64.tar.gz && \
+#     tar -C /tmp --strip-components=1 -zoxf /tmp/thanos.tar.gz && \
+#     rm -f /tmp/thanos.tar.gz && \
+#     mv /tmp/thanos /bin/ && \
+COPY --from=thanos /bin/thanos /bin/thanos
+RUN mkdir -p /thanos && \
     mkdir -p /etc/thanos && \
     chown -R nobody:nogroup /etc/thanos /thanos
 


### PR DESCRIPTION
Building a new Thanos image from the latest commits to master, as of 05/02/21.
This changes the standard pattern of using releases, but can be reverted once a release has been made.
This should hopefully resolve the issues we're seeing with Thanos around `internal server error`